### PR TITLE
Replace card with source

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -51,7 +51,7 @@ server.route({
         var options = {
             amount: request.payload.amount,
             currency: config.currency,
-            card: request.payload.stripeToken,
+            source: request.payload.stripeToken,
             metadata: _.extend({
                 buyer_email: request.payload.stripeEmail,
             }, request.payload.metadata),


### PR DESCRIPTION
Why:
The latest Stripe API expects the token to be sent via an option called source, not card.

https://stripe.com/docs/api/node#create_charge
